### PR TITLE
fix teaser installation name and links

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,8 +176,8 @@
       <h2>Programme</h2>
       <h3 class="date">Ongoing</h3>
       <section class="fold" data-fold="feld">
-        <strong data-fold-header="feld"><span class="date">16:00 - 22:00</span> ~ "FELD_" <span class="event-type">GPS installation</span> <span class="event-location">@ in the yard</span></strong>
-        <p data-fold-content="feld">Lucien Danzeisen and Lennart Melzer share different projects: With "FELD_", they created a site-specific composition with an open form: 347 GPS spots=soundfiles on Tempelhofer Feld, Berlin. See feld.zerkabelt.de for more infos. As "teaser", the duo plays experimental music between improvisation, concepts and compositions, using different setups, including acoustic and electronical instruments and live-coding. For Y-E-S Fest, they bring these two artistic practices together, in field:teaser, which is both a concert and a site-specific sound-installation. <a href="https://teaser.zerkabelt.de" target="_blank">https://teaser.zerkabelt.de</a></p>
+        <strong data-fold-header="feld"><span class="date">16:00 - 22:00</span> ~ "field:teaser" <span class="event-type">GPS installation</span> <span class="event-location">@ in the yard</span></strong>
+        <p data-fold-content="feld">Lucien Danzeisen and Lennart Melzer share different projects: With "FELD_", they created a site-specific composition with an open form: 347 GPS spots=soundfiles on Tempelhofer Feld, Berlin. See feld.zerkabelt.de for more infos. As "teaser", the duo plays experimental music between improvisation, concepts and compositions, using different setups, including acoustic and electronical instruments and live-coding. For Y-E-S Fest, they bring these two artistic practices together, in field:teaser, which is both a concert and a site-specific sound-installation. <a href="https://teaser.zerkabelt.de/y-e-s-2022/" target="_blank">https://teaser.zerkabelt.de/y-e-s-2022/</a></p>
       </section>
       <hr />
       <h3 class="date">Saturday 10.09.</h3>
@@ -186,8 +186,8 @@
         <p data-fold-content="position">Welcome and release celebration of Heft #132 of <a target="_blank" href="https://www.positionen.berlin/index.html">Positionen</a> magazine. Yes!</p>
       </section>
       <section class="fold" data-fold="feld-p">
-        <strong data-fold-header="feld-p"><span class="date">17:00 - 18:00</span> ~ "FELD_:teaser part 2" <span class="event-type">Performance</span> <span class="event-location">@ in Heizhaus</span></strong>
-        <p data-fold-content="feld-p">Danzeisen and Melzer will perform live as an addition to their installation "FELD_", the concert and the sounds from the installation are complementary to each other.</p>
+        <strong data-fold-header="feld-p"><span class="date">17:00 - 18:00</span> ~ "field:teaser part 2" <span class="event-type">Performance</span> <span class="event-location">@ in Heizhaus</span></strong>
+        <p data-fold-content="feld-p">Danzeisen and Melzer will perform live as an addition to their installation "field:teaser", the concert and the sounds from the installation are complementary to each other. <a href="https://teaser.zerkabelt.de/y-e-s-2022/" target="_blank">https://teaser.zerkabelt.de/y-e-s-2022/</a></p>
       </section>
       <section class="fold" data-fold="yes1">
         <strong data-fold-header="yes1"><span class="date">18:00 - 22:00</span> ~ "Y-E-S All-Friends-Fun #1" <span class="event-type">Performances and Concerts</span> <span class="event-location">@ in Heizhaus</span></strong>


### PR DESCRIPTION
We (teaser) added a page for the field:teaser installation/concert on our website. This PR will directly link to it, so attendees will find (more in-depth) instructions for the Sound installation there.

This also corrects usages of the name FELD_ which only refers to the installation/project at Tempelhofer Feld.